### PR TITLE
Connect to correct network if configured

### DIFF
--- a/app/src/main/java/kitchen/binary/kitchendoorlock/Start.java
+++ b/app/src/main/java/kitchen/binary/kitchendoorlock/Start.java
@@ -206,27 +206,38 @@ public class Start extends ActionBarActivity {
         statusText.setText(R.string.try_unlock);
         new PerformActionTask().execute(actionUnlock);
     }
+    
+    boolean checkSSID(String ssid) {
+        return ssid != null
+            && (ssid.contains("legacy.binary-kitchen.de")
+                || ssid.contains("secure.binary-kitchen.de"));
+    }
 
     boolean checkState()
     {
-        if (isConfigured == false)
+        if (!isConfigured)
         {
             statusText.setText(R.string.setup_credentials);
             return false;
         }
 
         WifiManager wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
-        WifiInfo wifiInfo = wifiManager.getConnectionInfo();
 
-        String ssid = wifiInfo.getSSID();
-        if (!ssid.contains("legacy.binary-kitchen.de")
-                && !ssid.contains("secure.binary-kitchen.de"))
+        if (checkSSID(wifiManager.getConnectionInfo().getSSID()))
         {
+            return true;
+        } else {
+            List<WifiConfiguration> list = wifiManager.getConfiguredNetworks();
+            for (WifiConfiguration wifiConfig : list) {
+                if (checkSSID(wifiConfig.SSID)) {
+                    wifiManager.disconnect();
+                    wifiManager.enableNetwork(wifiConfig.networkId, true);
+                    return true;
+                }
+            }
             statusText.setText(R.string.wrong_wifi);
             return false;
         }
-
-        return true;
     }
 
     public void onScan(View view)

--- a/app/src/main/java/kitchen/binary/kitchendoorlock/Start.java
+++ b/app/src/main/java/kitchen/binary/kitchendoorlock/Start.java
@@ -230,9 +230,8 @@ public class Start extends ActionBarActivity {
             List<WifiConfiguration> list = wifiManager.getConfiguredNetworks();
             for (WifiConfiguration wifiConfig : list) {
                 if (checkSSID(wifiConfig.SSID)) {
-                    wifiManager.disconnect();
-                    wifiManager.enableNetwork(wifiConfig.networkId, true);
-                    return true;
+                    if (wifiManager.enableNetwork(wifiConfig.networkId, true))
+                        return true;
                 }
             }
             statusText.setText(R.string.wrong_wifi);


### PR DESCRIPTION
First check if the current WiFi's SSID is one of the doorlock-enabled networks. If not, connect to one of them if they were previously configured.

Adapted from https://stackoverflow.com/questions/8818290
